### PR TITLE
[42] Updated prod cluster to include Celery/Redis

### DIFF
--- a/production-compose.yml
+++ b/production-compose.yml
@@ -1,11 +1,30 @@
 www:
   restart: always
+  command: /usr/local/bin/gunicorn web.wsgi:application -w 2 -b :8000 --reload
   build: ./www
+  links:
+    - redis:redis
   expose:
     - "8000"
   env_file:
     - .env
     - .env_prod
+
+celery:
+  restart: always
+  command: /usr/local/bin/celery -A web worker -l debug
+  build: ./www
+  volumes_from:
+    - www
+  links:
+    - redis:redis
+  env_file:
+    - .env
+    - .env_prod
+
+redis:
+  restart: always
+  image: redis
 
 nginx:
   restart: always

--- a/www/face_matcher/migrations/0002_auto_20160411_2034.py
+++ b/www/face_matcher/migrations/0002_auto_20160411_2034.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('face_matcher', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='history',
+            options={'ordering': ('-created_at',)},
+        ),
+        migrations.AlterModelOptions(
+            name='historyitem',
+            options={'ordering': ('-similarity_score',)},
+        ),
+    ]


### PR DESCRIPTION
Ticket: https://tree.taiga.io/project/magrossi-ca675-cloud-technologies-assignment-3/us/42

Tasks:
- Updated prod compose file to respect latest Celery/Redis dependency in master
- Fixed Regression: Added missing dependency for changed model ordering 
- Deployed and test prod build (but taking machine down for now to save money :heart:)

<img width="1236" alt="screen shot 2016-04-11 at 21 39 31" src="https://cloud.githubusercontent.com/assets/2990344/14441726/15eb6bd2-002e-11e6-9c56-dc002b412891.png">
